### PR TITLE
글꼴 개선

### DIFF
--- a/src/common/style.pcss
+++ b/src/common/style.pcss
@@ -7,12 +7,11 @@
 
 @layer base {
     :root {
-        --font-family-sans: "Noto Sans KR", "Noto Sans JP", "Malgun Gothic", "Dotum", sans-serif;
+        --font-family-sans: "Noto Sans KR", "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Malgun Gothic", "Dotum", sans-serif;
     }
 
     :lang(ja) {
-        --font-family-sans: "Noto Sans JP", sans-serif;
-        font-family: var(--font-family-sans);
+        --font-family-sans: "Noto Sans JP", -apple-system, BlinkMacSystemFont, sans-serif;
     }
 }
 

--- a/src/common/style.pcss
+++ b/src/common/style.pcss
@@ -1,5 +1,5 @@
 @import url(@fortawesome/fontawesome-free/css/all.min.css);
-@import url(https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@600;800&family=Noto+Sans+KR:wght@600;800&display=swap);
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Noto+Sans+KR:wght@100..900&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/domain/board/Board.vue
+++ b/src/domain/board/Board.vue
@@ -11,7 +11,7 @@
             <PostEditor :ticker="props.ticker" :placeholder="boardInfo.phTopic" :post="node" :reload="loadViewForce" />
           </div>
           <div v-else>
-            <div v-if="node.root" class="text-2xl">{{node.topic}}</div>
+            <div v-if="node.root" class="text-2xl font-bold">{{node.topic}}</div>
             <div class="flex pt-2 pb-2 px-3 mt-5 as-box text-sm">
               <div class="flex-1"><i class="fa-solid fa-user mr-1.5"></i> {{node.name}}</div>
               <div class="ml-4">


### PR DESCRIPTION
타 프로젝트에서 폰트 관련을 손대면서 이것도 좀 손봐야겠다 싶어서 PR 남깁니다.

- 일단 애플 디바이스에서 샌프란시스코 등 애플의 신형 시스템 폰트를 호출할 수 있도록 조치했습니다.
- 호출되는 노토 산즈의 굵기를 다양화 했습니다. 가변 글꼴 노토 산즈는 윈도우 환경에서도 생각보다 볼만하기도 하고, 모바일, 맥 같은 비 윈도우 환경에서는 오히려 폰트가 굵게 보이는 문제가 있어서요.
- 게시물 제목 폰트를 목록과 일관성을 맞추기 위해서 볼드체로 출력하도록 수정했습니다.